### PR TITLE
Updated Readme to reflect current flags and default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,18 @@ where `<input-files>` refers to source-code files containing OpenACC constructs.
 
 The tool supports the following optional flags:
 
+* `-[no-]declare-mapper` (default: **enabled**)
+Declares mappers for user-defined data-types (Fortran only).
 * `-[no-]force-backup` (default: **disabled**)
 Enforces the translator to write a backup file with .original extension of the processed file even if a backed up file exists. If disabled, the tool will refuse to proceed with the translation.
 * `-[no-]generate-report` (default: **enabled**)
 Generates a translation report into a separate file with the .report extension.
 * `-[no-]generate-multidimensional-alternate-code` (default: **enabled**)
 Provides implementation suggestions for _acc enter_/_acc exit_ constructs to be employed if the multi-dimensional data is non-contiguous (only in C).
+* `-host_data=<target_data,target_update>` (default: **target_update**)
+Specifies how to convert HOST_DATA clauses:
+    * `target_data` employs _!$omp target data_.
+    * `target_update` employs _!$omp target update_ using host memory.
 * `-keep-binding-clauses=[none,all,gang,worker,vector]` (defaut: **none**)
 Specifies which OpenACC hardware binding clauses (none, all, or a comma-separated combination of:_gang_, _worker_ or _vector_) are kept in the translation.
 * `-[no-]overwrite-input` (default: **disabled**)
@@ -73,8 +79,14 @@ Specifies how the tool translates OpenACC's present clause:
 Selects how the async OpenACC clauses are translated.
    * `ignore` -- do ignore the _async_ and _wait_ clauses -- note that this might have a performance impact.
    * `nowait` -- convert into _nowait_ and _taskwait_ clauses but this is not semantically equivalent to OpenACC.
+* `-specify-language=<auto,C,C++,Fortran/Free,Fortran/Fixed>` (default: **auto**)
+Forces the parsing of the file for language.
 * `-[no-]suppress-openacc` (default: **disabled**)
 The translator removes the OpenACC constructs in the translated file.
+* `-[no-]openacc-conditional-define` (default: **disabled**)
+The tool wraps the OpenACC source code with `#ifdef OPENACC2OPENMP_OPENACC` pre-processing macros.
+* `-openacc-conditional-define=X`
+The tool wraps the OpenACC source code with `#if defined(X)` pre-processing macros.
 * `-[no-]translated-openmp-conditional-define` (default: **disabled**)
 The tool wraps the translated OpenMP code with `#if defined(OPENACC2OPENMP_TRANSLATED_OPENMP)` pre-processing macros.
 * `-translated-openmp-conditional-define=X`

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Provides implementation suggestions for _acc enter_/_acc exit_ constructs to be 
 Specifies which OpenACC hardware binding clauses (none, all, or a comma-separated combination of:_gang_, _worker_ or _vector_) are kept in the translation.
 * `-[no-]overwrite-input` (default: **disabled**)
 When enabled, the translator will overwrite the input file with the translation file.
-* `-present=<alloc,tofrom,keep>` (default: **alloc**)
+* `-present=<alloc,tofrom,keep>` (default: **keep**)
 Specifies how the tool translates OpenACC's present clause:
     * `alloc` -- into OpenMP's _map(alloc)_.
     * `tofrom` -- into OpenMP's _map(tofrom)_. Note that this is may be less performant.
@@ -73,13 +73,13 @@ Specifies how the tool translates OpenACC's present clause:
 Selects how the async OpenACC clauses are translated.
    * `ignore` -- do ignore the _async_ and _wait_ clauses -- note that this might have a performance impact.
    * `nowait` -- convert into _nowait_ and _taskwait_ clauses but this is not semantically equivalent to OpenACC.
-* `-[no-]supress-openacc` (default: **disabled**)
+* `-[no-]suppress-openacc` (default: **disabled**)
 The translator removes the OpenACC constructs in the translated file.
-* `-[no-]-translated-openmp-conditional-define` (default: **disabled**)
+* `-[no-]translated-openmp-conditional-define` (default: **disabled**)
 The tool wraps the translated OpenMP code with `#if defined(OPENACC2OPENMP_TRANSLATED_OPENMP)` pre-processing macros.
 * `-translated-openmp-conditional-define=X`
 The tool wraps the translated OpenMP code with `#if defined(X)` pre-processing macros.
-* `-[no-]-original-openmp-conditional-define` (default: **disabled**)
+* `-[no-]original-openmp-conditional-define` (default: **enabled**)
 The tool wraps the original OpenMP code with `#if defined(OPENACC2OPENMP_ORIGINAL_OPENMP)` pre-processing macros.
 * `-original-openmp-conditional-define=X`
 The tool wraps the original code with `#if defined(X)` pre-processing macros.
@@ -90,11 +90,11 @@ Go to [top](#top)
 
 The tool supports some experimental features which are under development.
 
-* `-[no-]experimental-kernels-support` (default: **enabled**)
+* `-[no-]experimental-kernels-support` (default: **disabled**)
 On Fortran codes, the tool breaks the _loop_ constructs nested within _kernels_ into independent code regions to be executed back-to-back.
 **NOTE**: Resulting code may not OpenMP compliant -- depending on the _kernels_ and _loop_ locations. In some circumstances, you may need to manually change the code.
 **PERFORMANCE NOTE**: This feature might inject OpenMP constructs that lead to empty-kernel executions. We encourage you to visit the code and manually remove the existing empty-kernels, if any.
-* `-[no-]experimental-remove-kernels-bubbles` (default: **enabled**)
+* `-[no-]experimental-remove-kernels-bubbles` (default: **disabled**)
 This option attempts to remove empty OpenMP _target_ and _end target_ constructs injected through the use of `-experimental-kernels-support`.
 
 Go to [top](#top)

--- a/src/migrate_openacc_2_openmp.py
+++ b/src/migrate_openacc_2_openmp.py
@@ -95,7 +95,7 @@ def showHelp():
 	print ("                                if the multi-dimensional data is non-contiguous")
 	print (" -host_data=<target_data,target_update> : Specifies how to convert HOST_DATA clauses                      (target_update)")
 	print ("                                - target_data employs !$omp target data")
-	print ("                                - target_data employs !$omp target update, using host memory.")
+	print ("                                - target_update employs !$omp target update, using host memory.")
 	print (" -keep-binding-clauses=X      : Specifies which hardware binding clauses are kept in OpenMP               (none)")
 	print ("                                Where X can be: all, none, and a combination of gang, worker and vector")
 	print (" [-no]-overwrite-input        : Enables/Disables overwriting the original file with the translation.      (disabled)")


### PR DESCRIPTION
In the README there are some typos, missing flags and incorrect default values.

Updated default values:
- `-original-openmp-conditional-define`: disabled -> enabled
- `-present`: alloc -> keep
- `-experimental-kernels-support`: enabled -> disabled
- `-experimental-remove-kernels-bubbles`: enabled -> disabled

Added descriptions similar to help page for:
- `-declare-mapper`
- `-host_data`
- `-specify-language`
- `-openacc-conditional-define`

Fixed typo in `-[no-]suppress-openacc` and removed some unnecessary '-' in parameter list