### PR TITLE
Fixed wrong variable names and unwanted kernel construct behavior

### DIFF
--- a/src/migrate_openacc_2_openmp.py
+++ b/src/migrate_openacc_2_openmp.py
@@ -9,7 +9,6 @@ import migrate_openacc_2_openmp_parser as PARSER
 import sys
 import os
 import shutil
-import re
 from enum import Enum
 
 class FortranVariant(Enum):
@@ -72,7 +71,7 @@ def generateReport(lang, construct, infilename, APIwarnings):
 
 			report.close()
 	except IOError:
-		print (f"Error! File {infile} is not accessible for writing.")
+		print (f"Error! File {infilename} is not accessible for writing.")
 
 def showHelp():
 	print ("Intel(r) Application Migration Tool for OpenACC* to OpenMP*")
@@ -422,7 +421,7 @@ def entry(argv):
 					f.write (" ")
 					f.write (sys.argv[j])
 				f.write (" ")
-				f.write (argv[i])
+				f.write (argv[-1])
 				f.write ("\n")
 				f.close()
 		except IOError:

--- a/src/migrate_openacc_2_openmp_codegen.py
+++ b/src/migrate_openacc_2_openmp_codegen.py
@@ -106,7 +106,7 @@ def removeTargetEndTargetBubbles (txConfig, lines, constructs, supplementaryCons
 #  c = construct
 #  arraySections = description of the array and sections
 def generateAlternateMDCode_C(f, c, arraySections):
-	enter_or_exit = "enter" if c.startswith ("target enter data") else "exit";
+	enter_or_exit = "enter" if c.startswith ("target enter data") else "exit"
 	for part in TT.extractArraySections_C (arraySections):
 		direction, varslices = part
 		for varslice in varslices:
@@ -118,7 +118,7 @@ def generateAlternateMDCode_C(f, c, arraySections):
 				tailrange = slices[len(slices)-1]
 				f.write ( "// ATTENTION! The following suggested code is an alternative reference implementation\n")
 				f.write (f"// ATTENTION! that could be used if {varname} is a non-contiguous allocated multi-dimensional array\n")
-				depth = 0;
+				depth = 0
 				sectionprefix = ""
 				for r in slicesm1:
 					offset, length = r[0], r[1]
@@ -243,7 +243,7 @@ def generateTranslatedFileC (txConfig, lines, ACCconstructs, OMPconstructs, Supp
 #  c = construct
 #  arraySections = description of the array and slices
 def generateAlternateMDCode_Fortran(f, c, arraySections):
-	enter_or_exit = "enter" if c.startswith ("target enter data") else "exit";
+	enter_or_exit = "enter" if c.startswith ("target enter data") else "exit"
 	for part in TT.extractArraySections_Fortran (arraySections):
 		direction, varslices = part
 		for varslice in varslices:
@@ -260,7 +260,7 @@ def generateAlternateMDCode_Fortran(f, c, arraySections):
 				for declvar in slicesm1:
 					f.write (f"! integer :: idx{cnt}\n")
 					cnt = cnt + 1
-				depth = 0;
+				depth = 0
 				sectionprefix = ""
 				for r in slicesm1:
 					offset, length = r[0], r[1]
@@ -326,7 +326,7 @@ def generateTranslatedFileFortran (txConfig, lines, ACCconstructs, OMPconstructs
 						# If it didn't match, check that there is no other OpenACC statement
 						# in the destination line
 						if fkACCconstruct.bline-1 in ACCconstructs:
-							print ("Error! OpenACC statement already exists in {fkACCconstruct.bline-1}. Cannot add !$omp declare target in there!")
+							print (f"Error! OpenACC statement already exists in {fkACCconstruct.bline-1}. Cannot add !$omp declare target in there!")
 							print ("{}".format(ACCconstructs[fkACCconstruct.bline].openmp))
 							sys.exit (0)
 						# Ok, insert the fake ACC construct

--- a/src/migrate_openacc_2_openmp_constants.py
+++ b/src/migrate_openacc_2_openmp_constants.py
@@ -46,7 +46,7 @@ class BindingClauses(IntEnum):
 	NONE = 0                                     # No binding clause translated
 	GANG = 1 << 0                                # gang / num_gangs
 	WORKER = 1 << 1                              # worker / num_workers
-	VECTOR =  1 << 2                             # vector / vector_length
+	VECTOR = 1 << 2                              # vector / vector_length
 	ALL = GANG | WORKER | VECTOR                 # All above
 
 # vim:set noexpandtab tabstop=4:

--- a/src/migrate_openacc_2_openmp_convert.py
+++ b/src/migrate_openacc_2_openmp_convert.py
@@ -857,7 +857,7 @@ def translate_oacc_2_omp_acc_parallel(txConfig, c, carryOnStatus):
 	warnings = []
 
 	# do we have a worksharing (loop) construct ?
-	if ' loop ' in c.construct:
+	if ' loop' in c.construct:
 		c.hasLoop = True
 		carryOnStatus, _ = translate_oacc_2_omp_acc_loop(None, txConfig, c, carryOnStatus, None)
 
@@ -1193,14 +1193,14 @@ def translate_oacc_2_omp_acc_end_host_data(txConfig, c, carryOnStatus):
 	elif txConfig.HostDataBehavior == CONSTANTS.HostDataBehavior.TARGET_UPDATE:
 		omp_construct = ["target update"]
 		if "host_data" not in carryOnStatus:
-			print (f"Error! Cannot find the matching opening construct for '{omp_construct}'")
+			print (f"Error! Cannot find the matching opening construct for '{c.construct}'")
 			sys.exit (-1)
 		# Grab the variables used in the opening section
 		variables = carryOnStatus["host_data"]
 		if len(variables) > 0:
 			omp_clauses.append (f"to({variables})")
 		else:
-			print (f"Error! The matching opening construct for '{omp_construct}' does not include variables.")
+			print (f"Error! The matching opening construct for '{c.construct}' does not include variables.")
 			sys.exit (-1)
 		# Remove the key entry in the carryOnStatus dictionary
 		del carryOnStatus["host_data"]

--- a/src/migrate_openacc_2_openmp_parser.py
+++ b/src/migrate_openacc_2_openmp_parser.py
@@ -250,7 +250,7 @@ def parseFile_C(filename):
 	return lines, ACCconstructs, OMPconstructs, None # Last None refers to UDT definitions
 
 # getNextStatement_FTN_FX (lines, curline, breakOnPreprocessor):
-#  parses a fortran statement, which can be splitted in multiple lines on a FTN FX form
+#  parses a fortran statement, which can be split in multiple lines on a FTN FX form
 #  if breakOnPreprocessor, would stop parsing when finding a CPP preprocessor
 #  such as #ifdef or #define .
 def getNextStatement_FTN_FX(lines, curline, breakOnPreprocessor = False):
@@ -370,7 +370,7 @@ def getConstructOnMultiline_FTN_FX(sentinel, lines, curline):
 			    l[0] not in ['c','!','*']:
 				print (f"Error! Ill-formed construct around line {begin_line+1} when looking for '{sentinel}' sentinel")
 				sys.exit(-1)
-			# Append into the construct if it contain the sentinel, otherwise the
+			# Append into the construct if it contains the sentinel, otherwise the
 			# line refers to a comment
 			if l.startswith ("c$" + sentinel) or \
 			   l.startswith ("!$" + sentinel) or \
@@ -621,7 +621,7 @@ def getConstructOnMultiline_FTN_FR(sentinel, lines, curline):
 	return original, construct, begin_line, curline
 
 # getNextStatement_FTN_FR (lines, curline, breakOnPreprocessor):
-#  parses a fortran statement, which can be splitted in multiple lines on a FTN FR form
+#  parses a fortran statement, which can be split in multiple lines on a FTN FR form
 #  if breakOnPreprocessor, would stop parsing when finding a CPP preprocessor
 #  such as #ifdef or #define .
 def getNextStatement_FTN_FR(lines, curline, breakOnPreprocessor = False):

--- a/src/migrate_openacc_2_openmp_tools.py
+++ b/src/migrate_openacc_2_openmp_tools.py
@@ -2,7 +2,6 @@
 # Helper tools module for "Intel(r) Application Migration Tool for OpenACC* to OpenMP*"
 #
 
-import migrate_openacc_2_openmp_constants as CONSTANTS
 import re
 
 # findClosingParenthesis (s, pos, line, lines)
@@ -86,7 +85,7 @@ def findClosingBrackets (line, pos, lines):
 #
 # searchForEndOfDeclarationOrImplementation_C (startline, lines)
 #  checks from startline whether the following symbol is a declaration symbol
-#  or an function implementation
+#  or a function implementation
 #
 def searchForEndOfDeclarationOrImplementation_C (startlineno, lines):
 	endlineno = startlineno
@@ -177,7 +176,7 @@ def extractArraySectionComponents_Fortran(var_component):
 #   generates a list of tuples of variable names and the array sections indicated.
 #   For instance:
 #     map(to:_filter[0:_size][0:_size]) map(alloc:_var[1:_size1][2:_size2][3:_size3],_var2[10:20])
-#   gets splitted into two components (one for to and for alloc directions), and then each
+#   gets split into two components (one for to and for alloc directions), and then each
 #   record it generates a tuple of variable + list of rangemin/rangemax pairs
 #     1) [('to', [('_filter', [('0', '_size'), ('0', '_size')])])
 #     2) ('alloc', [('_var', [('1', '_size1'), ('2', '_size2'), ('3', '_size3')])]), ('alloc', [('_var2', [('10', '20')])])]

--- a/src/migrate_openacc_2_openmp_udt.py
+++ b/src/migrate_openacc_2_openmp_udt.py
@@ -13,8 +13,8 @@ def splitEntities (entities):
 			# There is a comma and a parenthesis at least,
 			# check which comes first
 			if comma_pos < open_parenthesis_pos:
-				# Comma first, process entitiy
-				tmp = entities[:comma_pos] # Keep first entitity in comma-separated list
+				# Comma first, process entity
+				tmp = entities[:comma_pos] # Keep first entity in comma-separated list
 				tmp = tmp.strip()
 				if len(tmp) > 0:
 					res = res + [tmp]
@@ -71,7 +71,7 @@ def splitEntities (entities):
 def getUDTMembers (UDT):
 
 	# Process all members found in the user-defined-type
-	# Process them line-by-line, and aggregate results into sentitites -- which is a set of splitted entities
+	# Process them line-by-line, and aggregate results into sentitites -- which is a set of split entities
 	sentities = []
 	for m in UDT.members:
 		if m.startswith ("#"):


### PR DESCRIPTION
In the code there are some places where the naming of the variables doesn't seem to be right and the behavior of the migration is to sensitive about the naming of variables. 

Renaming of old/wrong variable names:
- printing errors of malformed input code
- reading `wait` with `ignore` behavior

Also I added a special case when the name of a variable in the `kernels` construct contains the word `block`. Otherwise the code thinks a `BLOCK` construct starts which is incorrect.