### PR TITLE
Fixed removal of last char on multiline construct

### DIFF
--- a/src/migrate_openacc_2_openmp_parser.py
+++ b/src/migrate_openacc_2_openmp_parser.py
@@ -564,7 +564,9 @@ def getConstructOnMultiline_FTN_FR(sentinel, lines, curline):
 	multiline = True
 
 	while multiline:
-		construct = construct[:-1] # do not include multi-line trailing & char in Fortran/Free form
+		# do not include multi-line trailing & char in Fortran/Free form
+		if len(construct) > 0 and construct[-1] == '&':
+			construct = construct[:-1]
 
 		l = lines[curline].strip()
 		original.append (l)


### PR DESCRIPTION
Fixed wrong removal of last `&` on multiline construct when reading empty line.
The following Fortran code provides an example on how to reproduce the error:

```fortran
!$ACC DATA &
!$ACC PRESENT(a) &

! Some comment
!$ACC CREATE(b)
```

When using the code above the internal construct would save `data present(a create(b)` after parsing, because it would suppress the last char after reading an empty line without checking if the char is really an `&`.