### PR TITLE
Honor section 2.6 / Data environment for default() clause and kernels (scalar) constructs

### DIFF
--- a/src/migrate_openacc_2_openmp_convert.py
+++ b/src/migrate_openacc_2_openmp_convert.py
@@ -406,30 +406,33 @@ def translate_oacc_2_omp_acc_data(txConfig, c):
 		if defaultv == "present":
 			# We have to honor user's request on how to process the
 			# present clause
+			# According to OpenACC spec (e.g. spec 3.3, page 39, section 2.6, line 1307)
+			# Any default(present) clause visible at the compute construct applies to
+			# aggregate variables
 			if txConfig.PresentBehavior == CONSTANTS.PresentBehavior.ALLOC:
 				omp_clauses.append ("defaultmap(alloc:aggregate)")
-				omp_clauses.append ("defaultmap(alloc:pointer)")
 				if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 				   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
 					omp_clauses.append ("defaultmap(alloc:allocatable)")
 			elif txConfig.PresentBehavior == CONSTANTS.PresentBehavior.TOFROM:
 				omp_clauses.append ("defaultmap(tofrom:aggregate)")
-				omp_clauses.append ("defaultmap(tofrom:pointer)")
 				if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 				   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
 					omp_clauses.append ("defaultmap(tofrom:allocatable)")
 			elif txConfig.PresentBehavior == CONSTANTS.PresentBehavior.KEEP:
 				omp_clauses.append ("defaultmap(present:aggregate)")
-				omp_clauses.append ("defaultmap(present:pointer)")
 				if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 				   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
 					omp_clauses.append ("defaultmap(present:allocatable)")
 		elif defaultv == "none":
+			# According to OpenACC spec (e.g. spec 3.3, page 39, section 2.6, line 1306)
+			# Any default(none) clause visible at the compute construct applies to
+			# both aggregate and scalar variables
 			omp_clauses.append ("defaultmap(none:aggregate)")
-			omp_clauses.append ("defaultmap(none:pointer)")
 			if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 			   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
-				omp_clauses.append ("defaultmap(none:allocatable)")
+				omp_clauses.append ("defaultmap(present:allocatable)")
+			omp_clauses.append ("defaultmap(none:scalar)")
 
 	# Store data back into the construct class
 	c.openmp = [ " ".join(omp_construct + omp_clauses) ]
@@ -645,30 +648,33 @@ def translate_oacc_2_omp_acc_kernels (lines, txConfig, c, carryOnStatus):
 		if defaultv == "present":
 			# We have to honor user's request on how to process the
 			# present clause
+			# According to OpenACC spec (e.g. spec 3.3, page 39, section 2.6, line 1307)
+			# Any default(present) clause visible at the compute construct applies to
+			# aggregate variables
 			if txConfig.PresentBehavior == CONSTANTS.PresentBehavior.ALLOC:
 				omp_clauses.append ("defaultmap(alloc:aggregate)")
-				omp_clauses.append ("defaultmap(alloc:pointer)")
 				if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 				   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
 					omp_clauses.append ("defaultmap(alloc:allocatable)")
 			elif txConfig.PresentBehavior == CONSTANTS.PresentBehavior.TOFROM:
 				omp_clauses.append ("defaultmap(tofrom:aggregate)")
-				omp_clauses.append ("defaultmap(tofrom:pointer)")
 				if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 				   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
 					omp_clauses.append ("defaultmap(tofrom:allocatable)")
 			elif txConfig.PresentBehavior == CONSTANTS.PresentBehavior.KEEP:
 				omp_clauses.append ("defaultmap(present:aggregate)")
-				omp_clauses.append ("defaultmap(present:pointer)")
 				if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 				   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
 					omp_clauses.append ("defaultmap(present:allocatable)")
 		elif defaultv == "none":
+			# According to OpenACC spec (e.g. spec 3.3, page 39, section 2.6, line 1306)
+			# Any default(none) clause visible at the compute construct applies to
+			# both aggregate and scalar variables
 			omp_clauses.append ("defaultmap(none:aggregate)")
-			omp_clauses.append ("defaultmap(none:pointer)")
 			if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 			   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
-				omp_clauses.append ("defaultmap(none:allocatable)")
+				omp_clauses.append ("defaultmap(present:allocatable)")
+			omp_clauses.append ("defaultmap(none:scalar)")
 
 	# Process wait clause
 	if ' wait(' in c.construct:
@@ -685,6 +691,11 @@ def translate_oacc_2_omp_acc_kernels (lines, txConfig, c, carryOnStatus):
 		elif txConfig.AsyncBehavior == CONSTANTS.AsyncBehavior.NOWAIT:
 			omp_clauses.append ("nowait")
 		warnings.append (PREDEFINED_WARNINGS["missing_async"])
+
+	# According to OpenACC spec (e.g. spec 3.3, page 39, section 2.6, line 1304)
+	#  a scalar variable will be treated as if it appears in a copy clause if the compute
+	#  construct is is a kernels construct
+	omp_clauses.append ("defaultmap(tofrom:scalar)")
 
 	# Store data back into the construct class
 	#  keep those already collected in c.openmp/warnings if this
@@ -953,30 +964,33 @@ def translate_oacc_2_omp_acc_parallel(txConfig, c, carryOnStatus):
 		if defaultv == "present":
 			# We have to honor user's request on how to process the
 			# present clause
+			# According to OpenACC spec (e.g. spec 3.3, page 39, section 2.6, line 1307)
+			# Any default(present) clause visible at the compute construct applies to
+			# aggregate variables
 			if txConfig.PresentBehavior == CONSTANTS.PresentBehavior.ALLOC:
 				omp_clauses.append ("defaultmap(alloc:aggregate)")
-				omp_clauses.append ("defaultmap(alloc:pointer)")
 				if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 				   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
 					omp_clauses.append ("defaultmap(alloc:allocatable)")
 			elif txConfig.PresentBehavior == CONSTANTS.PresentBehavior.TOFROM:
 				omp_clauses.append ("defaultmap(tofrom:aggregate)")
-				omp_clauses.append ("defaultmap(tofrom:pointer)")
 				if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 				   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
 					omp_clauses.append ("defaultmap(tofrom:allocatable)")
 			elif txConfig.PresentBehavior == CONSTANTS.PresentBehavior.KEEP:
 				omp_clauses.append ("defaultmap(present:aggregate)")
-				omp_clauses.append ("defaultmap(present:pointer)")
 				if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 				   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
 					omp_clauses.append ("defaultmap(present:allocatable)")
 		elif defaultv == "none":
+			# According to OpenACC spec (e.g. spec 3.3, page 39, section 2.6, line 1306)
+			# Any default(none) clause visible at the compute construct applies to
+			# both aggregate and scalar variables
 			omp_clauses.append ("defaultmap(none:aggregate)")
-			omp_clauses.append ("defaultmap(none:pointer)")
 			if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 			   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
-				omp_clauses.append ("defaultmap(none:allocatable)")
+				omp_clauses.append ("defaultmap(present:allocatable)")
+			omp_clauses.append ("defaultmap(none:scalar)")
 
 	# Process wait clause
 	if ' wait(' in c.construct:
@@ -1047,30 +1061,33 @@ def translate_oacc_2_omp_acc_serial(txConfig, c, carryOnStatus):
 		if defaultv == "present":
 			# We have to honor user's request on how to process the
 			# present clause
+			# According to OpenACC spec (e.g. spec 3.3, page 39, section 2.6, line 1307)
+			# Any default(present) clause visible at the compute construct applies to
+			# aggregate variables
 			if txConfig.PresentBehavior == CONSTANTS.PresentBehavior.ALLOC:
 				omp_clauses.append ("defaultmap(alloc:aggregate)")
-				omp_clauses.append ("defaultmap(alloc:pointer)")
 				if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 				   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
 					omp_clauses.append ("defaultmap(alloc:allocatable)")
 			elif txConfig.PresentBehavior == CONSTANTS.PresentBehavior.TOFROM:
 				omp_clauses.append ("defaultmap(tofrom:aggregate)")
-				omp_clauses.append ("defaultmap(tofrom:pointer)")
 				if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 				   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
 					omp_clauses.append ("defaultmap(tofrom:allocatable)")
 			elif txConfig.PresentBehavior == CONSTANTS.PresentBehavior.KEEP:
 				omp_clauses.append ("defaultmap(present:aggregate)")
-				omp_clauses.append ("defaultmap(present:pointer)")
 				if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 				   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
 					omp_clauses.append ("defaultmap(present:allocatable)")
 		elif defaultv == "none":
+			# According to OpenACC spec (e.g. spec 3.3, page 39, section 2.6, line 1306)
+			# Any default(none) clause visible at the compute construct applies to
+			# both aggregate and scalar variables
 			omp_clauses.append ("defaultmap(none:aggregate)")
-			omp_clauses.append ("defaultmap(none:pointer)")
 			if txConfig.Lang == CONSTANTS.FileLanguage.FortranFixed or \
 			   txConfig.Lang == CONSTANTS.FileLanguage.FortranFree:
-				omp_clauses.append ("defaultmap(none:allocatable)")
+				omp_clauses.append ("defaultmap(present:allocatable)")
+			omp_clauses.append ("defaultmap(none:scalar)")
 
 	# Process wait clause
 	if ' wait(' in c.construct:

--- a/tests/C/0001.c.reference
+++ b/tests/C/0001.c.reference
@@ -3,20 +3,20 @@ int main (int argc, char*argv[])
 	int x;
 
 	#pragma acc kernels
-#pragma omp target
+#pragma omp target defaultmap(tofrom:scalar)
 	{
 		x = 2;
 	}
 
 	_Pragma("acc kernels")
-#pragma omp target
+#pragma omp target defaultmap(tofrom:scalar)
 	{
 	x = 3;
 	}
 
 	_Pragma("acc \
 	 kernels")
-#pragma omp target
+#pragma omp target defaultmap(tofrom:scalar)
 	{
 	x = 4;
 	}
@@ -24,4 +24,4 @@ int main (int argc, char*argv[])
 	return 0;
 }
 
-// Code was translated using: ../src/openacc2openmp.py -no-generate-multidimensional-alternate-code -no-conditional-define -force-backup C/0001.c
+// Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all C

--- a/tests/C/0001.h.reference
+++ b/tests/C/0001.h.reference
@@ -1,17 +1,17 @@
 #pragma acc kernels
-#pragma omp target
+#pragma omp target defaultmap(tofrom:scalar)
 {
 }
 
 _Pragma("acc kernels")
-#pragma omp target
+#pragma omp target defaultmap(tofrom:scalar)
 {
 }
 
 _Pragma("acc \
  kernels")
-#pragma omp target
+#pragma omp target defaultmap(tofrom:scalar)
 {
 }
 
-// Code was translated using: ../src/openacc2openmp.py -no-generate-multidimensional-alternate-code -no-conditional-define -force-backup C/0001.h
+// Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all C

--- a/tests/C/0009.c.reference
+++ b/tests/C/0009.c.reference
@@ -4,7 +4,7 @@ int main (int argc, char *argv[])
 	int A[N];
 
 	#pragma acc kernels
-#pragma omp target
+#pragma omp target defaultmap(tofrom:scalar)
 	{
 		#pragma acc loop
 #pragma omp loop
@@ -13,12 +13,12 @@ int main (int argc, char *argv[])
 	}
 
 	#pragma acc kernels loop
-#pragma omp target teams loop
+#pragma omp target teams loop defaultmap(tofrom:scalar)
 	for (int i = 0; i < N; ++i)
 		A[i] = i;
 
 	#pragma acc kernels
-#pragma omp target
+#pragma omp target defaultmap(tofrom:scalar)
 	#pragma acc loop
 #pragma omp loop
 	for (int i = 0; i < N; ++i)
@@ -27,4 +27,4 @@ int main (int argc, char *argv[])
 	return 0;
 }
 
-// Code was translated using: /nfs/pdx/home/hservatg/src/openacc2openmp.git/src/openacc2openmp.py -no-generate-multidimensional-alternate-code -no-conditional-define -force-backup 0009.c
+// Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all C

--- a/tests/C/0012.c.reference
+++ b/tests/C/0012.c.reference
@@ -1,7 +1,7 @@
 int main (int argc, char *argv[])
 {
 	#pragma acc kernels
-#pragma omp target
+#pragma omp target defaultmap(tofrom:scalar)
 	{
 		int oneliner_stmt = 0;
 		#pragma acc loop
@@ -70,4 +70,4 @@ int main (int argc, char *argv[])
 	}
 }
 
-// Code was translated using: /nfs/pdx/home/hservatg/src/openacc2openmp.git/src/openacc2openmp.py -no-generate-multidimensional-alternate-code -no-conditional-define -force-backup 0012.c
+// Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all C

--- a/tests/C/0019-present.c.reference
+++ b/tests/C/0019-present.c.reference
@@ -17,8 +17,7 @@ int main (void)
 #pragma omp target data map(alloc:v)
 	{
 		#pragma acc parallel loop default(present)
-#pragma omp target teams loop defaultmap(present:aggregate)\
-            defaultmap(present:pointer)
+#pragma omp target teams loop defaultmap(present:aggregate)
 		for (unsigned i = 0; i < 10; ++i)
 			v[i] = 2*i;
 		#pragma acc update host(v)
@@ -27,4 +26,4 @@ int main (void)
 	return 0;
 }
 
-// Code was translated using: /nfs/pdx/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all 0019-present.c
+// Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all C

--- a/tests/C/0024-kernels-and-copy.c.reference
+++ b/tests/C/0024-kernels-and-copy.c.reference
@@ -4,7 +4,7 @@ int main (int argc, char*argv[])
 	unsigned a[N],b[N];
 
 	#pragma acc kernels copyout(a[0:N])
-#pragma omp target map(from:a[0:N])
+#pragma omp target map(from:a[0:N]) defaultmap(tofrom:scalar)
 	{
 		#pragma acc loop
 #pragma omp loop
@@ -12,7 +12,7 @@ int main (int argc, char*argv[])
 			a[i] = i+1;
 	}
 	#pragma acc kernels copyin(a[0:N]) copyout(b[0:N])
-#pragma omp target map(to:a[0:N]) map(from:b[0:N])
+#pragma omp target map(to:a[0:N]) map(from:b[0:N]) defaultmap(tofrom:scalar)
 	{
 		#pragma acc loop
 #pragma omp loop
@@ -20,7 +20,7 @@ int main (int argc, char*argv[])
 			b[i] = a[i] + 1;
 	}
 	#pragma acc kernels copyin(a[0:N]) copyout(b[0:N])
-#pragma omp target map(to:a[0:N]) map(from:b[0:N])
+#pragma omp target map(to:a[0:N]) map(from:b[0:N]) defaultmap(tofrom:scalar)
 	{
 		#pragma acc loop
 #pragma omp loop
@@ -32,11 +32,12 @@ int main (int argc, char*argv[])
 			b[i] = a[i] + 1;
 	}
 	#pragma acc kernels loop copyin(a[0:N]) copyout(b[0:N])
-#pragma omp target teams loop map(to:a[0:N]) map(from:b[0:N])
+#pragma omp target teams loop map(to:a[0:N]) map(from:b[0:N])\
+            defaultmap(tofrom:scalar)
 	for (unsigned i = 0; i < N; ++i)
 		b[i] = a[i] + 1;
 
 	return 0;
 }
 
-// Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup 0024-kernels-and-copy.c
+// Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all C

--- a/tests/C/0027-hostdata.c.reference
+++ b/tests/C/0027-hostdata.c.reference
@@ -5,7 +5,7 @@ int main()
 #pragma omp target data map(to:a,b)
 	{
 		#pragma acc kernels
-#pragma omp target
+#pragma omp target defaultmap(tofrom:scalar)
 		{
 			for (int i = 0; i < 1000; ++i)
 				a[i] = i;

--- a/tests/Fortran/Fixed/0001.f.reference
+++ b/tests/Fortran/Fixed/0001.f.reference
@@ -1,10 +1,10 @@
       program test
       integer i
 !$acc kernels
-!$omp target
+!$omp target defaultmap(tofrom:scalar)
       i = 0
 !$acc end kernels
 !$omp end target
       end program
 
-! Code was translated using: ../src/openacc2openmp.py -no-generate-multidimensional-alternate-code -no-conditional-define -force-backup -fixed Fortran/Fixed/0001.f
+! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all Fortran

--- a/tests/Fortran/Fixed/0009.f.reference
+++ b/tests/Fortran/Fixed/0009.f.reference
@@ -5,7 +5,7 @@
       integer :: A(N)
 
 !$acc kernels
-!$omp target
+!$omp target defaultmap(tofrom:scalar)
 !$acc loop
 !$omp loop
       do i = 1,N
@@ -15,7 +15,7 @@
 !$omp end target
 
 !$acc kernels
-!$omp target
+!$omp target defaultmap(tofrom:scalar)
 
 !$acc loop
 !$omp loop
@@ -27,7 +27,7 @@
 !$omp end target
 
 !$acc kernels loop
-!$omp target teams loop
+!$omp target teams loop defaultmap(tofrom:scalar)
       do i = 1,N
          a(i) = i+1
       end do
@@ -53,4 +53,4 @@
 
       end program
 
-! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all -fixed 0009.f
+! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all Fortran

--- a/tests/Fortran/Fixed/0012.f.reference
+++ b/tests/Fortran/Fixed/0012.f.reference
@@ -3,7 +3,7 @@
       integer i, j, k, l, m
 
 !$acc kernels
-!$omp target
+!$omp target defaultmap(tofrom:scalar)
 !$acc loop
 !$omp loop
         do i = 1, 10
@@ -41,4 +41,4 @@
 
       end program
 
-! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all -fixed 0012.f
+! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all Fortran

--- a/tests/Fortran/Fixed/0019-present.f.reference
+++ b/tests/Fortran/Fixed/0019-present.f.reference
@@ -22,7 +22,7 @@
 !$omp target data map(alloc:v)
 !$acc parallel loop default(present)
 !$omp target teams loop defaultmap(present:aggregate)
-!$omp& defaultmap(present:pointer) defaultmap(present:allocatable)
+!$omp& defaultmap(present:allocatable)
         do i = 1, 10
           v(i) = i
         end do
@@ -35,4 +35,4 @@
 
       end program
 
-! Code was translated using: /nfs/pdx/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all -fixed 0019-present.f
+! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all Fortran

--- a/tests/Fortran/Fixed/0024-kernels-and-copy.f.reference
+++ b/tests/Fortran/Fixed/0024-kernels-and-copy.f.reference
@@ -6,7 +6,7 @@
       integer :: i
 
 !$acc kernels copyin(a)
-!$omp target map(to:a)
+!$omp target map(to:a) defaultmap(tofrom:scalar)
 !$acc loop
 !$omp loop
       do i=1,n
@@ -16,7 +16,7 @@
 !$omp end target
 
 !$acc kernels copyin(a) copyout(b)
-!$omp target map(to:a) map(from:b)
+!$omp target map(to:a) map(from:b) defaultmap(tofrom:scalar)
 !$acc loop
 !$omp loop
       do i=1,n
@@ -26,7 +26,7 @@
 !$omp end target
 
 !$acc kernels copyin(a) copyout(b)
-!$omp target map(to:a) map(from:b)
+!$omp target map(to:a) map(from:b) defaultmap(tofrom:scalar)
 !$acc loop
 !$omp loop
       do i=1,n
@@ -42,6 +42,7 @@
 
 !$acc kernels loop copyin(a) copyout(b)
 !$omp target teams loop map(to:a) map(from:b)
+!$omp& defaultmap(tofrom:scalar)
       do i=1,n
         b(i) = a(i) + 1
       enddo
@@ -51,4 +52,4 @@
       end subroutine foo
 
 
-! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup 0024-kernels-and-copy.f
+! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all Fortran

--- a/tests/Fortran/Fixed/0027-hostdata.f.reference
+++ b/tests/Fortran/Fixed/0027-hostdata.f.reference
@@ -4,7 +4,7 @@
       !$acc data copyin(a,b)
 !$omp target data map(to:a,b)
         !$acc kernels
-!$omp target
+!$omp target defaultmap(tofrom:scalar)
         do i = 1, 1000
           a(i) = i
         enddo

--- a/tests/Fortran/Free/0001.f90.reference
+++ b/tests/Fortran/Free/0001.f90.reference
@@ -1,10 +1,10 @@
 program test
 integer i
 !$acc kernels
-!$omp target
+!$omp target defaultmap(tofrom:scalar)
 i = 0
 !$acc end kernels
 !$omp end target
 end program
 
-! Code was translated using: ../src/openacc2openmp.py -no-generate-multidimensional-alternate-code -no-conditional-define -force-backup -free Fortran/Free/0001.f90
+! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all Fortran

--- a/tests/Fortran/Free/0009.f90.reference
+++ b/tests/Fortran/Free/0009.f90.reference
@@ -5,7 +5,7 @@ integer :: i
 integer :: A(N)
 
 !$acc kernels
-!$omp target
+!$omp target defaultmap(tofrom:scalar)
 
 !$acc loop
 !$omp loop
@@ -17,7 +17,7 @@ integer :: A(N)
 !$omp end target
 
 !$acc kernels
-!$omp target
+!$omp target defaultmap(tofrom:scalar)
 !$acc loop
 !$omp loop
    do i = 1,N
@@ -27,7 +27,7 @@ integer :: A(N)
 !$omp end target
 
 !$acc kernels loop
-!$omp target teams loop
+!$omp target teams loop defaultmap(tofrom:scalar)
    do i = 1,N
     a(i) = i+1
    end do
@@ -53,4 +53,4 @@ integer :: A(N)
 
 end program
 
-! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all -free 0009.f90
+! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all Fortran

--- a/tests/Fortran/Free/0012.f90.reference
+++ b/tests/Fortran/Free/0012.f90.reference
@@ -3,7 +3,7 @@ implicit none
 integer i, j, k, l, m
 
   !$acc kernels
-!$omp target
+!$omp target defaultmap(tofrom:scalar)
   !$acc loop
 !$omp loop
   do i = 1, 10
@@ -41,4 +41,4 @@ integer i, j, k, l, m
 
 end program
 
-! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all -free 0012.f90
+! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all Fortran

--- a/tests/Fortran/Free/0019-present.f90.reference
+++ b/tests/Fortran/Free/0019-present.f90.reference
@@ -22,7 +22,7 @@ v(:) = 0
 !$omp target data map(alloc:v)
   !$acc parallel loop default(present)
 !$omp target teams loop defaultmap(present:aggregate)&
-!$omp defaultmap(present:pointer) defaultmap(present:allocatable)
+!$omp defaultmap(present:allocatable)
   do i = 1, 10
     v(i) = i
   end do
@@ -35,4 +35,4 @@ v(:) = 0
 
 end program
 
-! Code was translated using: /nfs/pdx/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all -free 0019-present.f90
+! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all Fortran

--- a/tests/Fortran/Free/0024-kernels-and-copy.f90.reference
+++ b/tests/Fortran/Free/0024-kernels-and-copy.f90.reference
@@ -6,7 +6,7 @@ subroutine foo(a, b, n)
   integer :: i
 
 !$acc kernels copyout(a)
-!$omp target map(from:a)
+!$omp target map(from:a) defaultmap(tofrom:scalar)
 !$acc loop
 !$omp loop
 do i=1,n
@@ -16,7 +16,7 @@ enddo
 !$omp end target
 
 !$acc kernels copyin(a) copyout(b)
-!$omp target map(to:a) map(from:b)
+!$omp target map(to:a) map(from:b) defaultmap(tofrom:scalar)
 !$acc loop
 !$omp loop
 do i=1,n
@@ -26,7 +26,7 @@ enddo
 !$omp end target
 
 !$acc kernels copyin(a) copyout(b)
-!$omp target map(to:a) map(from:b)
+!$omp target map(to:a) map(from:b) defaultmap(tofrom:scalar)
 !$acc loop
 !$omp loop
 do i=1,n
@@ -41,7 +41,8 @@ enddo
 !$omp end target
 
 !$acc kernels loop copyin(a) copyout(b)
-!$omp target teams loop map(to:a) map(from:b)
+!$omp target teams loop map(to:a) map(from:b)&
+!$omp defaultmap(tofrom:scalar)
 do i=1,n
   b(i) = a(i) + 1
 enddo
@@ -50,4 +51,4 @@ enddo
 
 end subroutine foo
 
-! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup 0024-kernels-and-copy.f90
+! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all Fortran

--- a/tests/Fortran/Free/0027-hostdata.f90.reference
+++ b/tests/Fortran/Free/0027-hostdata.f90.reference
@@ -4,7 +4,7 @@ integer :: i
 !$acc data copyin(a,b)
 !$omp target data map(to:a,b)
   !$acc kernels
-!$omp target
+!$omp target defaultmap(tofrom:scalar)
   do i = 1, 1000
     a(i) = i
   enddo

--- a/tests/specific-tests/async=nowait/0001.c.reference
+++ b/tests/specific-tests/async=nowait/0001.c.reference
@@ -3,13 +3,13 @@ int main (int argc, char*argv[])
 	int x;
 
 	#pragma acc kernels async(1)
-#pragma omp target nowait
+#pragma omp target nowait defaultmap(tofrom:scalar)
 	{
 		x = 2;
 	}
 
 	_Pragma("acc kernels async(2)")
-#pragma omp target nowait
+#pragma omp target nowait defaultmap(tofrom:scalar)
 	{
 	x = 3;
 	}
@@ -17,7 +17,7 @@ int main (int argc, char*argv[])
 	_Pragma("acc \
 	 kernels async(3) wait(1)")
 #pragma omp taskwait
-#pragma omp target nowait
+#pragma omp target nowait defaultmap(tofrom:scalar)
 	{
 	x = 4;
 	}
@@ -30,4 +30,4 @@ int main (int argc, char*argv[])
 	return 0;
 }
 
-// Code was translated using: /nfs/pdx/home/hservatg/src/openacc2openmp.git/src/openacc2openmp.py -no-generate-multidimensional-alternate-code -no-conditional-define -force-backup -keep-binding-clauses=all -async=nowait 0001.c
+// Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all -async=nowait specific-tests/async=nowait

--- a/tests/specific-tests/async=nowait/0001.f.reference
+++ b/tests/specific-tests/async=nowait/0001.f.reference
@@ -1,19 +1,19 @@
       program test
       integer i
 !$acc kernels async(1)
-!$omp target nowait
+!$omp target nowait defaultmap(tofrom:scalar)
       i = 0
 !$acc end kernels
 !$omp end target
 !$acc kernels async(2) wait(1)
 !$omp taskwait
-!$omp target nowait
+!$omp target nowait defaultmap(tofrom:scalar)
       i = 0
 !$acc end kernels
 !$omp end target
 !$acc kernels async(3) wait (2)
 !$omp taskwait
-!$omp target nowait
+!$omp target nowait defaultmap(tofrom:scalar)
       i = 0
 !$acc end kernels
 !$omp end target
@@ -21,4 +21,4 @@
 !$omp taskwait
       end program
 
-! Code was translated using: /nfs/pdx/home/hservatg/src/openacc2openmp.git/src/openacc2openmp.py -no-generate-multidimensional-alternate-code -no-conditional-define -force-backup -keep-binding-clauses=all -fixed -async=nowait 0001.f
+! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all -async=nowait specific-tests/async=nowait

--- a/tests/specific-tests/async=nowait/0001.f90.reference
+++ b/tests/specific-tests/async=nowait/0001.f90.reference
@@ -1,12 +1,12 @@
 program test
 integer i
 !$acc kernels async(1)
-!$omp target nowait
+!$omp target nowait defaultmap(tofrom:scalar)
 i = 0
 !$acc end kernels
 !$omp end target
 !$acc kernels async(2)
-!$omp target nowait
+!$omp target nowait defaultmap(tofrom:scalar)
 i = 0
 !$acc end kernels
 !$omp end target
@@ -16,4 +16,4 @@ i = 0
 !$omp taskwait
 end program
 
-! Code was translated using: /nfs/pdx/home/hservatg/src/openacc2openmp.git/src/openacc2openmp.py -no-generate-multidimensional-alternate-code -no-conditional-define -force-backup -keep-binding-clauses=all -free -async=nowait 0001.f90
+! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -keep-binding-clauses=all -async=nowait specific-tests/async=nowait

--- a/tests/specific-tests/preprocessor-guards/0001.c.reference
+++ b/tests/specific-tests/preprocessor-guards/0001.c.reference
@@ -6,7 +6,7 @@ int main (int argc, char*argv[])
 	#pragma acc kernels
 #endif // defined(OPENACC2OPENMP_OPENACC)
 #if defined(OPENACC2OPENMP_TRANSLATED_OPENMP)
-#pragma omp target
+#pragma omp target defaultmap(tofrom:scalar)
 #endif // defined(OPENACC2OPENMP_TRANSLATED_OPENMP)
 	{
 		x = 2;
@@ -16,7 +16,7 @@ int main (int argc, char*argv[])
 	_Pragma("acc kernels")
 #endif // defined(OPENACC2OPENMP_OPENACC)
 #if defined(OPENACC2OPENMP_TRANSLATED_OPENMP)
-#pragma omp target
+#pragma omp target defaultmap(tofrom:scalar)
 #endif // defined(OPENACC2OPENMP_TRANSLATED_OPENMP)
 	{
 	x = 3;
@@ -27,7 +27,7 @@ int main (int argc, char*argv[])
 	 kernels")
 #endif // defined(OPENACC2OPENMP_OPENACC)
 #if defined(OPENACC2OPENMP_TRANSLATED_OPENMP)
-#pragma omp target
+#pragma omp target defaultmap(tofrom:scalar)
 #endif // defined(OPENACC2OPENMP_TRANSLATED_OPENMP)
 	{
 	x = 4;
@@ -36,4 +36,4 @@ int main (int argc, char*argv[])
 	return 0;
 }
 
-// Code was translated using: /nfs/pdx/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -openacc-conditional-define -translated-openmp-conditional-define 0001.c
+// Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -openacc-conditional-define -translated-openmp-conditional-define specific-tests/preprocessor-guards

--- a/tests/specific-tests/preprocessor-guards/0001.f.reference
+++ b/tests/specific-tests/preprocessor-guards/0001.f.reference
@@ -4,7 +4,7 @@
 !$acc kernels
 #endif // defined(OPENACC2OPENMP_OPENACC)
 #if defined(OPENACC2OPENMP_TRANSLATED_OPENMP)
-!$omp target
+!$omp target defaultmap(tofrom:scalar)
 #endif // defined(OPENACC2OPENMP_TRANSLATED_OPENMP)
       i = 0
 #if defined(OPENACC2OPENMP_OPENACC)
@@ -15,4 +15,4 @@
 #endif // defined(OPENACC2OPENMP_TRANSLATED_OPENMP)
       end program
 
-! Code was translated using: /nfs/pdx/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -openacc-conditional-define -translated-openmp-conditional-define 0001.f
+! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -openacc-conditional-define -translated-openmp-conditional-define specific-tests/preprocessor-guards

--- a/tests/specific-tests/preprocessor-guards/0001.f90.reference
+++ b/tests/specific-tests/preprocessor-guards/0001.f90.reference
@@ -4,7 +4,7 @@ integer i
 !$acc kernels
 #endif // defined(OPENACC2OPENMP_OPENACC)
 #if defined(OPENACC2OPENMP_TRANSLATED_OPENMP)
-!$omp target
+!$omp target defaultmap(tofrom:scalar)
 #endif // defined(OPENACC2OPENMP_TRANSLATED_OPENMP)
 i = 0
 #if defined(OPENACC2OPENMP_OPENACC)
@@ -15,4 +15,4 @@ i = 0
 #endif // defined(OPENACC2OPENMP_TRANSLATED_OPENMP)
 end program
 
-! Code was translated using: /nfs/pdx/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -openacc-conditional-define -translated-openmp-conditional-define 0001.f90
+! Code was translated using: /nfs/site/home/hservatg/src/intel-application-migration-tool-for-openacc-to-openmp/src/intel-application-migration-tool-for-openacc-to-openmp -force-backup -openacc-conditional-define -translated-openmp-conditional-define specific-tests/preprocessor-guards


### PR DESCRIPTION
OpenACC SPEC 3.3 / Section 2.6 states

1303 A scalar variable will be treated as if it appears either:
**1304 • In a copy clause if the compute construct is a kernels construct.**
1305 • In a firstprivate clause otherwise.

and

**1306 Note: Any default(none) clause visible at the compute construct applies to both aggregate
1307 and scalar variables. However, any default(present) clause visible at the compute construct
1308 applies only to aggregate variables.**

 Highlighted was not implemented fully in the translator. This PR should address this.